### PR TITLE
Added WS_B_Move binding and added logic to tabenter

### DIFF
--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -235,6 +235,7 @@ augroup end
 command! -nargs=1 WS call WS_Open("<args>")
 command! -nargs=1 WSc call WS_Close("<args>")
 command! -nargs=1 WSmv call WS_Rename("<args>")
+command! -nargs=1 WSbm call WS_B_Move("<args>")
 
 function! s:init()
     for t in range(1, tabpagenr("$"))

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -193,11 +193,26 @@ function! s:tabenter()
     if ! get(t:, "WS")
         call s:tabinit()
     endif
-    for b in WS_Buffers(t:WS)
+    let switchbuf = 1
+    let bnr = bufnr("%")
+    let wsbuffers = WS_Buffers(t:WS)
+    for b in wsbuffers 
         if get(b.variables, "WS_listed")
             call s:buflisted(b.bufnr, 1)
+            if(bnr == b.bufnr)
+              let switchbuf = 0
+            endif
         endif
     endfor
+    if(0 == len(WS_Buffers(t:WS)))
+        let switchbuf = 0
+        enew
+        call s:bufdummy()
+    endif
+    if(switchbuf)
+        let b = get(wsbuffers, 0, 0) 
+        exe "buffer " . b.bufnr
+    endif
 endfunc
 
 function! s:bufadd(bnr)


### PR DESCRIPTION
In nvim when open A buffer in tab X, then switch to tab Y and open buffer A again. Now going back tab X, buffer A still shows even though not in buffer list. Updates made to create new buffer or use an existing buffer to replace A buffer.

Also found WS_B_Move so I added bindings called WSbm