### PR TITLE
Adde binding for WS_B_Move & fix a problem with zombie buffers in nvim

### DIFF
--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -31,7 +31,8 @@ function! WS_Open(WS)
     else
         exe WS_Tabnum(a:WS, 1) . "tabnew"
         call WS_Rename(a:WS)
-        call s:bufdummy()
+        enew
+        " call s:bufdummy()
     endif
     echo WS_Line()
     return ! tabnum
@@ -234,12 +235,16 @@ function! s:tabenter()
             endif
         endif
     endfor
-    if(empty(target))
+    if(empty(target)) 
         let switchbuf = 0
         enew
-        call s:bufdummy()
     endif
-    if(switchbuf && !empty(target))
+    " loaded hidden
+    " 1      1      exe
+    " 1      0      no
+    " 0      ?      exe
+    if(switchbuf && !empty(target) && !(getbufinfo(target.bufnr)[0].loaded == 1 && getbufinfo(target.bufnr)[0].hidden == 0))
+        echo 'swiiitch'
         exe "buffer " . target.bufnr 
     endif
 endfunc
@@ -257,8 +262,17 @@ function! s:bufenter()
         let b:WS = get(b.variables, "WS")
         let tabnum = WS_Tabnum(b:WS)
         if tabnum
+            let foundWindow = 0
             exe "tabnext " . tabnum
-            exe "buffer " . b.bufnr 
+              for wid in win_findbuf(b.bufnr)
+                  if tabnum == win_id2tabwin(wid)[0]
+                      let foundWindow= 1
+                      call win_gotoid(wid)
+                  endif
+              endfor
+            if(!foundWindow)
+              exe "buffer " . b.bufnr 
+            endif
         endif
       endif
     endfor
@@ -302,5 +316,4 @@ function! s:init()
 endfunc
 
 call s:init()
-
 

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -235,6 +235,7 @@ augroup end
 command! -nargs=1 WS call WS_Open("<args>")
 command! -nargs=1 WSc call WS_Close("<args>")
 command! -nargs=1 WSmv call WS_Rename("<args>")
+command! -nargs=1 WSbm call WS_B_Move("<args>")
 
 function! s:init()
     for t in range(1, tabpagenr("$"))

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -38,7 +38,13 @@ function! WS_Open(WS)
         setl bufhidden=wipe
         " call s:bufdummy()
     endif
-    echo WS_Line()
+
+    if !exists("g:workspace#vim#airline#enable")
+      let g:workspace#vim#airline#enable = 0
+    endif
+    if(!g:workspace#vim#airline#enable)
+      echo WS_Line()
+    endif
     return ! tabnum
 endfunc
 
@@ -61,6 +67,27 @@ function! s:isbufdummy(b)
         let b = getbufinfo(b)[0]
     endif
     return ! b.changed && b.name == ""
+endfunc
+
+function! WS_Letter()
+    if !exists("g:workspace#vim#airline#enable")
+      let g:workspace#vim#airline#enable = 0
+    endif
+    if(!g:workspace#vim#airline#enable)
+      return ''
+    endif
+    let st = []
+    " let char = "\u0336"
+    let char = "\u0332"
+    for t in range(1, tabpagenr("$"))
+        let tWS = gettabvar(t, "WS")
+        if t == tabpagenr()
+          call add(st, tWS . char)
+        else
+          call add(st, tWS)
+        endif
+    endfor
+    return join(st, " | ")
 endfunc
 
 function! WS_Line()
@@ -297,6 +324,12 @@ function! s:bufenter()
     let b:WS = t:WS
     " Workaround for BufAdd
     call s:collect_orphans()
+
+    let g:airline#extensions#tabline#buffers_label = WS_Letter() 
+endfunc
+
+function! s:bufwinenter()
+    let g:airline#extensions#tabline#buffers_label = WS_Letter() 
 endfunc
 
 augroup workspace
@@ -306,6 +339,7 @@ augroup workspace
     autocmd TabClosed   * nested call s:tabclosed()
     "autocmd BufAdd     * nested call s:bufadd(expand("<abuf>"))
     autocmd BufEnter    * nested call s:bufenter()
+    autocmd WinEnter    * nested call s:bufwinenter()
 augroup end
 
 command! -nargs=1 WS call WS_Open("<args>")

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -79,15 +79,16 @@ function! WS_Letter()
     let st = []
     " let char = "\u0336"
     let char = "\u0332"
+    " let char = ''
     for t in range(1, tabpagenr("$"))
         let tWS = gettabvar(t, "WS")
         if t == tabpagenr()
-          call add(st, tWS . char)
+          call add(st, '%1*' . tWS . char . '%')
         else
-          call add(st, tWS)
+          call add(st, '%2*' . tWS  . '%')
         endif
     endfor
-    return join(st, "  ")
+    return join(st, "\ \ ") . ' '
 endfunc
 
 function! WS_Line()
@@ -229,7 +230,6 @@ function! s:collect_orphans()
 endfunc
 
 function! s:tableave()
-    " call s:cleanallemptybuffers()
     let s:prev = t:WS
     for b in WS_Buffers(t:WS)
         if b.listed
@@ -325,8 +325,37 @@ function! s:bufenter()
     " Workaround for BufAdd
     call s:collect_orphans()
 
-    let g:airline#extensions#tabline#buffers_label = WS_Letter() 
+    let g:airline#extensions#tabline#buffers_label = WS_Letter()
 endfunc
+
+function! s:returnhighlightterm(group, term)
+   " Store output of group to variable
+   let output = execute('hi ' . a:group)
+
+   " Find the term we're looking for
+   return matchstr(output, a:term.'=\zs\S*')
+endfunction
+
+function! WorkspaceColor(...)
+  let guibg_color = s:returnhighlightterm('airline_tablabel_right', 'guibg')
+  let guifg_color =  s:returnhighlightterm('airline_tablabel_right', 'guifg')
+  let ctermfg_color = s:returnhighlightterm('airline_tablabel_right', 'ctermfg')
+  let ctermbg_color = s:returnhighlightterm('airline_tablabel_right', 'ctermbg')
+  let hi_command1 = 'hi User1 gui=bold guibg=' . guibg_color
+        \ . ' guifg=' . guifg_color
+        \ . ' ctermfg=' . ctermfg_color
+        \ . ' ctermbg=' . ctermbg_color
+  let hi_command2 = 'hi User2' 
+        \ . ' guibg=' . guibg_color
+        \ . ' guifg=' . guifg_color
+        \ . ' ctermfg=' . ctermfg_color
+        \ . ' ctermbg=' . ctermbg_color
+  exe printf(hi_command1) 
+  exe printf(hi_command2) 
+  hi link airline_tablabel_right User1
+endfunc
+
+call airline#add_statusline_func('WorkspaceColor')
 
 function! s:bufwinenter()
     let g:airline#extensions#tabline#buffers_label = WS_Letter() 

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -32,6 +32,8 @@ function! WS_Open(WS)
         exe WS_Tabnum(a:WS, 1) . "tabnew"
         call WS_Rename(a:WS)
         enew
+        setl nobuflisted
+        setl bufhidden=wipe
         " call s:bufdummy()
     endif
     echo WS_Line()
@@ -239,6 +241,8 @@ function! s:tabenter()
     if(empty(target)) 
         let switchbuf = 0
         enew
+        setl nobuflisted
+        setl bufhidden=wipe
     endif
     " loaded hidden
     " 1      1      exe
@@ -256,33 +260,29 @@ endfunc
 
 function! s:bufenter()
     let bnr = bufnr("%")
-    
 
-    if getbufvar(bnr, "WS_listed")
-      call s:buflisted(bnr, 1)
-    endif
-
-    for b in getbufinfo(bnr)
-      if b.listed 
-        let bWS = get(b.variables, "WS")
+    let bWS = get(b:, "WS")
+    if bWS && bWS != t:WS
         let tabnum = WS_Tabnum(bWS)
         if tabnum
             let foundWindow = 0
             exe "tabnext " . tabnum
-              for wid in win_findbuf(b.bufnr)
+              for wid in win_findbuf(bnr)
                   if tabnum == win_id2tabwin(wid)[0]
                       let foundWindow= 1
                       call win_gotoid(wid)
                   endif
               endfor
             if(!foundWindow)
-              exe "buffer " . b.bufnr 
+              exe "buffer " . bnr 
             endif
         endif
-      endif
-    endfor
+    endif
 
     let b:WS = t:WS
+    if getbufvar(bnr, "WS_listed")
+      call s:buflisted(bnr, 1)
+    endif
     " Workaround for BufAdd
     call s:collect_orphans()
 endfunc

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -275,7 +275,7 @@ function! s:bufenter()
       endif
     endfor
 
-    if(b:WS == 0)
+    if(getbufvar(bnr, 'WS', 0) == 0)
       let b:WS = t:WS
     endif
     " Workaround for BufAdd
@@ -309,7 +309,7 @@ augroup end
 command! -nargs=1 WS call WS_Open("<args>")
 command! -nargs=1 WSc call WS_Close("<args>")
 command! -nargs=1 WSmv call WS_Rename("<args>")
-command! -nargs=1 WSbm call WS_B_Move("<args>")
+command! -nargs=1 WSbmv call WS_B_Move("<args>")
 
 function! s:init()
     for t in range(1, tabpagenr("$"))

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -90,13 +90,6 @@ endfunc
 
 function! WS_B_Move(to)
     let bnr = bufnr("%")
-    let alt = bufnr("#")
-    if alt == -1
-        enew
-        call s:bufdummy()
-    else
-        exe "buffer " . alt
-    endif
     call WS_Open(a:to)
     exe "buffer " . bnr
 endfunc
@@ -194,24 +187,27 @@ function! s:tabenter()
         call s:tabinit()
     endif
     let switchbuf = 1
+    let target = {} 
     let bnr = bufnr("%")
     let wsbuffers = WS_Buffers(t:WS)
     for b in wsbuffers 
         if get(b.variables, "WS_listed")
+            if(empty(target))
+               let target = b 
+            endif
             call s:buflisted(b.bufnr, 1)
             if(bnr == b.bufnr)
               let switchbuf = 0
             endif
         endif
     endfor
-    if(0 == len(WS_Buffers(t:WS)))
+    if(empty(target))
         let switchbuf = 0
         enew
         call s:bufdummy()
     endif
-    if(switchbuf)
-        let b = get(wsbuffers, 0, 0) 
-        exe "buffer " . b.bufnr
+    if(switchbuf && !empty(target))
+        exe "buffer " . target.bufnr 
     endif
 endfunc
 

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -261,6 +261,10 @@ endfunc
 function! s:bufenter()
     let bnr = bufnr("%")
 
+    if getbufvar(bnr, "WS_listed")
+      call s:buflisted(bnr, 1)
+    endif
+
     let bWS = get(b:, "WS")
     if bWS && bWS != t:WS
         let tabnum = WS_Tabnum(bWS)
@@ -280,9 +284,6 @@ function! s:bufenter()
     endif
 
     let b:WS = t:WS
-    if getbufvar(bnr, "WS_listed")
-      call s:buflisted(bnr, 1)
-    endif
     " Workaround for BufAdd
     call s:collect_orphans()
 endfunc

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -193,11 +193,26 @@ function! s:tabenter()
     if ! get(t:, "WS")
         call s:tabinit()
     endif
-    for b in WS_Buffers(t:WS)
+    let switchbuf = 1
+    let bnr = bufnr("%")
+    let wsbuffers = WS_Buffers(t:WS)
+    for b in wsbuffers 
         if get(b.variables, "WS_listed")
             call s:buflisted(b.bufnr, 1)
+            if(bnr == b.bufnr)
+              let switchbuf = 0
+            endif
         endif
     endfor
+    if(0 == len(WS_Buffers(t:WS)))
+        let switchbuf = 0
+        enew
+        call s:bufdummy()
+    endif
+    if(switchbuf)
+        let b = get(wsbuffers, 0, 0) 
+        exe "buffer " . b.bufnr
+    endif
 endfunc
 
 function! s:bufadd(bnr)

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -225,6 +225,7 @@ function! s:bufenter()
         let tabnum = WS_Tabnum(b:WS)
         if tabnum
             exe "tabnext " . tabnum
+            exe "buffer " . b.bufnr 
         endif
       endif
     endfor

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -217,8 +217,19 @@ function! s:bufadd(bnr)
 endfunc
 
 function! s:bufenter()
-    let b:WS = t:WS
     let bnr = bufnr("%")
+    
+    for b in getbufinfo(bnr)
+      if b.listed 
+        let b:WS = get(b.variables, "WS")
+        let tabnum = WS_Tabnum(b:WS)
+        if tabnum
+            exe "tabnext " . tabnum
+        endif
+      endif
+    endfor
+
+    let b:WS = t:WS
     if getbufvar(bnr, "WS_listed")
         call s:buflisted(bnr, 1)
     endif

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -12,6 +12,10 @@ if exists('loaded_workspace')
 endif
 let loaded_workspace = 1
 
+if !exists("g:workspace#vim#airline#enable")
+    let g:workspace#vim#airline#enable = 0
+endif
+
 if v:version < 700
     finish
 endif
@@ -39,9 +43,6 @@ function! WS_Open(WS)
         " call s:bufdummy()
     endif
 
-    if !exists("g:workspace#vim#airline#enable")
-      let g:workspace#vim#airline#enable = 0
-    endif
     if(!g:workspace#vim#airline#enable)
       echo WS_Line()
     endif
@@ -70,9 +71,6 @@ function! s:isbufdummy(b)
 endfunc
 
 function! WS_Letter()
-    if !exists("g:workspace#vim#airline#enable")
-      let g:workspace#vim#airline#enable = 0
-    endif
     if(!g:workspace#vim#airline#enable)
       return ''
     endif
@@ -239,6 +237,7 @@ function! s:tableave()
 endfunc
 
 function! s:tabenter()
+    let g:SessionLoad = 1
     if ! get(t:, "WS")
         call s:tabinit()
     endif
@@ -295,6 +294,7 @@ function! s:bufadd(bnr)
 endfunc
 
 function! s:bufenter()
+    let g:SessionLoad = 1
     let bnr = bufnr("%")
 
     if getbufvar(bnr, "WS_listed")
@@ -309,12 +309,12 @@ function! s:bufenter()
         if tabnum
             let foundWindow = 0
             exe "tabnext " . tabnum
-              for wid in win_findbuf(bnr)
-                  if tabnum == win_id2tabwin(wid)[0]
-                      let foundWindow= 1
-                      call win_gotoid(wid)
-                  endif
-              endfor
+            for wid in win_findbuf(bnr)
+                if tabnum == win_id2tabwin(wid)[0]
+                    let foundWindow= 1
+                    call win_gotoid(wid)
+                endif
+            endfor
             if(!foundWindow)
               exe "buffer " . bnr 
             endif
@@ -355,8 +355,10 @@ function! WorkspaceColor(...)
   hi link airline_tablabel_right User1
 endfunc
 
-call airline#add_statusline_func('WorkspaceColor')
-
+if g:workspace#vim#airline#enable
+  call airline#add_statusline_func('WorkspaceColor')
+endif
+ 
 function! s:bufwinenter()
     let g:airline#extensions#tabline#buffers_label = WS_Letter() 
 endfunc

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -157,10 +157,18 @@ function! s:tabclosed()
     for b in getbufinfo()
         let WS = get(b.variables, "WS")
         if WS && ! WS_Tabnum(WS)
-            if get(b.variables, "WS_listed")
+            " get prev tab
+            let bWS = WS_Tabnum(WS, 1)
+            " if 0 then use first tab
+            if(bWS == 0)
+              let firstTab = gettabinfo()[0]
+              let bWS = get(firstTab.variables, "WS")
+            endif
+            if bWS == t:WS && get(b.variables, "WS_listed")
                 call s:buflisted(b.bufnr, 1)
             endif
-            call setbufvar(b.bufnr, "WS", "")
+            " move buffer to prev tab, or first tab.
+            call setbufvar(b.bufnr, "WS", bWS)
         endif
     endfor
 endfunc

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -50,15 +50,24 @@ function! WS_Backforth()
     endif
 endfunc
 
+function! s:isbufdummy(b)
+    let b = a:b
+    if type(b) != v:t_dict
+        let b = getbufinfo(b)[0]
+    endif
+    return ! b.changed && b.name == ""
+endfunc
+
 function! WS_Line()
     let st = []
     for t in range(1, tabpagenr("$"))
         let tWS = gettabvar(t, "WS")
         if t == tabpagenr()
-            call add(st, "<".tWS.">")
-        else
-            call add(st, tWS)
+          let tWS = "<" . tWS . ">"
+        elseif WS_Empty(tWS)
+          continue
         endif
+        call add(st, tWS)
     endfor
     return " " . join(st, " | ")
 endfunc
@@ -151,6 +160,22 @@ function! s:buflisted(bufnum, listed)
         call setbufvar(a:bufnum, "WS_listed", 1)
         call setbufvar(a:bufnum, "&buflisted", 0)
     endif
+endfunc
+
+function! WS_Empty(WS)
+    let t = WS_Tabnum(a:WS)
+    if tabpagewinnr(t, "$") != 1
+        return v:false
+    endif
+    let bs = tabpagebuflist(t)
+    if len(bs) > 1 || ! s:isbufdummy(bs[0])
+        return v:false
+    endif
+    let bs = WS_Buffers(a:WS)
+    if len(bs) > 1
+        return v:false
+    endif
+    return len(bs) == 0 || s:isbufdummy(bs[0])
 endfunc
 
 function! s:tabclosed()
@@ -277,4 +302,5 @@ function! s:init()
 endfunc
 
 call s:init()
+
 

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -64,11 +64,10 @@ function! WS_Line()
     for t in range(1, tabpagenr("$"))
         let tWS = gettabvar(t, "WS")
         if t == tabpagenr()
-          let tWS = "<" . tWS . ">"
-        elseif WS_Empty(tWS)
-          continue
+          call add(st, "<" . tWS . ">")
+        else
+          call add(st, tWS)
         endif
-        call add(st, tWS)
     endfor
     return " " . join(st, " | ")
 endfunc
@@ -100,6 +99,7 @@ endfunc
 
 function! WS_B_Move(to)
     let bnr = bufnr("%")
+    call setbufvar(bnr, 'WS', a:to)
     call WS_Open(a:to)
     exe "buffer " . bnr
 endfunc
@@ -257,10 +257,15 @@ endfunc
 function! s:bufenter()
     let bnr = bufnr("%")
     
+
+    if getbufvar(bnr, "WS_listed")
+      call s:buflisted(bnr, 1)
+    endif
+
     for b in getbufinfo(bnr)
       if b.listed 
-        let b:WS = get(b.variables, "WS")
-        let tabnum = WS_Tabnum(b:WS)
+        let bWS = get(b.variables, "WS")
+        let tabnum = WS_Tabnum(bWS)
         if tabnum
             let foundWindow = 0
             exe "tabnext " . tabnum
@@ -278,9 +283,6 @@ function! s:bufenter()
     endfor
 
     let b:WS = t:WS
-    if getbufvar(bnr, "WS_listed")
-        call s:buflisted(bnr, 1)
-    endif
     " Workaround for BufAdd
     call s:collect_orphans()
 endfunc

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -87,7 +87,7 @@ function! WS_Letter()
           call add(st, tWS)
         endif
     endfor
-    return join(st, " | ")
+    return join(st, "  ")
 endfunc
 
 function! WS_Line()

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+Added WSbm to move buffers between tabs, and fix for nvim ...
+
 # workspace.vim
 
 The main purpose of this plugin is to make it easier

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,10 @@
 
 Forked following (workspace.vim) project. It allow to use tabs as workspaces to manage buffers similar to i3/sway.
 
+## For updating
+
+Please clean and reinstall from repository (last change: 2020-11-07 : airline-intergration)
+
 ## Changes compare to original
 * Can move buffers between tabs
 * :e, C-^, C-0, gd, gf, marks will try to seek buffer last tab and window 

--- a/readme.md
+++ b/readme.md
@@ -54,9 +54,10 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 ## changes compare to original
 
--Open existing buffer switch to that tab/buffer.
--Move tab between working spaces.
--C-^ move to that tab/buffer
+* Opening an already existing buffer switch to that tab/buffer.
+* Can move tab between working spaces.
+* C-^ switch tab then buffer.
+* Closing tab now move old buffer to previous left tab, if not then first tab.
 
 # workspace.vim
 

--- a/readme.md
+++ b/readme.md
@@ -37,21 +37,12 @@ nnoremap <silent> <leader><leader>3 :WSbmv 3<CR>
   .
 ```
 
-```vim
-" if you are using sessoin (ex. startify) close all tabs before exist,
-" otherwise opened buffers are not restored.
-autocmd VimLeavePre * nested call CloseAllTabs()
-
-fun! CloseAllTabs()
-  exe 'tabo'
-endfun
-```
-
 To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ever randomly close parent tabs, please use moll/vim-bbye or similar plugins to delete buffers. Just like i3/sway I do not think you should use WSc (close current workspace/tab) bcz empty workspaces will close automatically now.
 
 ## Airline integration
 
-```non-offecial airline intergration, see screenshot below
+```vim
+non-offecial airline intergration, see screenshot below
 let g:workspace#vim#airline#enable = 1
 .
 .
@@ -72,7 +63,9 @@ let g:airline#extensions#tabline#show_tab_count = 0
 
 If you are using Startfiy (or any session managmenet) you will notice that only last opened tab's buffers will be restored next time you read a session. The problem is that this plugin will actually &bufflisted=false buffer from other tabs and nvim will not save them to session file. To solve the problem use :tabo just before leaving nvim to clean all tabs and restore all buffers to &bufferlisted=true. A temporarly solution please use following:
 
-```
+```vim
+" if you are using sessoin (ex. startify) close all tabs before exist,
+" otherwise opened buffers are not restored.
 augroup closealltabs
   autocmd!
   autocmd VimLeavePre * nested :tabo

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ev
 ## Airline integration
 
 ```vim
-non-offecial airline intergration, see screenshot below
+" a non-offecial airline intergration, see screenshot below
 let g:workspace#vim#airline#enable = 1
 .
 .

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,8 @@
 ## Forked # workspace.vim
 
-Forked following (workspace.vim) project to allow to use tab as workspaces to manage buffers similar to i3/sway
+Forked following (workspace.vim) project to allow to use tab as workspaces to manage buffers similar to i3/sway. 
 
 my binding are:
-
 ```vim
 " create a new tab with N title or move to an exiting N tab.
 nnoremap <silent> <leader>1 :WS 1<CR>
@@ -13,6 +12,7 @@ nnoremap <silent> <leader>3 :WS 3<CR>
   .
   .
 ```
+
 ```vim
 " move current buffer to tab N
 nnoremap <silent> <leader><leader>1 :WSbmv 1<CR>
@@ -22,13 +22,14 @@ nnoremap <silent> <leader><leader>3 :WSbmv 3<CR>
   .
   .
 ```
+
 ```vim
-" c-^ alternative
+" c-^ alternative, i never use this shortcut though ...
 nnoremap <silent> <leader>` :call WS_Backforth()<CR>
 ```
 
 
-to move between buffers use :bn :bp or any buffer plugin.
+To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ever randomly close parent tabs, please use moll/vim-bbye or similar plugins to delete buffers. Just like i3/sway I do not think you should use WSc (close current workspace/tab) bcz empty workspaces will close automatically now.
 
 if you are using airline following setting produce best result:
 
@@ -53,12 +54,11 @@ let g:airline#extensions#tabline#show_tab_count = 2
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
 
 ## changes compare to original
-
-* Opening an already existing buffer switch to that tab/buffer.
-* Can move tab between working spaces.
-* C-^ switch tab then buffer.
-* Closing tab now move old buffer to previous left tab, if not then first tab.
-* Do not show empty workspaces (copied from original res)
+* Can move buffers between tabs
+* :e, C-^, C-0, gd, gf will try to seek buffer last tab and window 
+* Closing tab now move old buffer to previous left pos tab, 
+* Empty workspace (tabs) are actually removed
+* :bd should work fine
 
 # workspace.vim
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-## Forked
+## Forked # workspace.vim
 
 forked following project to allow to use tab as workspaces to manage buffers similar to i3/sway
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,30 @@
+## Forked
+
+forked following project to allow to use tab as workspaces to manage buffers similar to i3/sway
+
+my binding are:
+
+" create a new tab with N title or move to an exiting N tab.
+nnoremap <silent> <leader>1 :WS 1<CR>
+nnoremap <silent> <leader>2 :WS 2<CR>
+nnoremap <silent> <leader>3 :WS 3<CR>
+  .
+  .
+  .
+
+" move current buffer to tab N
+nnoremap <silent> <leader><leader>1 :WSbm 1<CR>
+nnoremap <silent> <leader><leader>2 :WSbm 2<CR>
+nnoremap <silent> <leader><leader>3 :WSbm 3<CR>
+  .
+  .
+  .
+  
+## Additional Usage. Refer Below for more
+
+* `:WSmb n` will move current buffer to workspace `n` (it is a number).
+
+
 # workspace.vim
 
 The main purpose of this plugin is to make it easier

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 ## Additional Usage. Refer Below for more
 
-* `:WSmb n` will move current buffer to workspace `n` (it is a number).
+* `:WSmbv n` will move current buffer to workspace `n` (it is a number).
 
 ## Images (Workspace <1> | 2)
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,9 @@ let g:workspace#vim#airline#enable = 1
 
 ## Images (Workspace <1> | 2)
 
+![screenshot_2020-11-07-162650](https://user-images.githubusercontent.com/355729/98434787-1decfe00-2116-11eb-9315-7efe9b497999.png)
+
+
 ![screenshot_2020-11-02-020612](https://user-images.githubusercontent.com/355729/97809539-b9164b80-1cb0-11eb-9e95-7e5837c81133.png)
 
 
@@ -68,7 +71,6 @@ let g:workspace#vim#airline#enable = 1
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
 
 
-![screenshot_2020-11-07-160424](https://user-images.githubusercontent.com/355729/98434454-19731600-2113-11eb-91ca-ad5ea60e1445.png)
 
 # workspace.vim (original Readme)
 

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,15 @@ nnoremap <silent> <leader><leader>3 :WSbm 3<CR>
   .
   .
 ```
+to move between buffers use :bn :bp or any buffer plugin.
+
+if you are using airline following setting produce best result:
+
+```vim
+let g:airline#extensions#tabline#enabled = 1
+let g:airline#extensions#tabline#show_tabs = 0
+let g:airline#extensions#tabline#show_tab_count = 2
+```
 
 ## Additional Usage. Refer Below for more
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,17 @@
 ## Forked # workspace.vim
 
-Forked following (workspace.vim) project to allow to use tab as workspaces to manage buffers similar to i3/sway. 
+Forked following (workspace.vim) project to allow to use tab as workspaces to manage buffers similar to i3/sway.
 
-my binding are:
+## changes compare to original
+* Can move buffers between tabs
+* :e, C-^, C-0, gd, gf will try to seek buffer last tab and window 
+* Closing tab now move old buffer to previous left pos tab, 
+* Empty workspace (tabs) are actually removed
+* :bd should work fine
+* Also check original fork bcz he is progressing too =D
+
+## My bindings and .vimrc
+
 ```vim
 " create a new tab with N title or move to an exiting N tab.
 nnoremap <silent> <leader>1 :WS 1<CR>
@@ -28,7 +37,6 @@ nnoremap <silent> <leader><leader>3 :WSbmv 3<CR>
 nnoremap <silent> <leader>` :call WS_Backforth()<CR>
 ```
 
-
 To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ever randomly close parent tabs, please use moll/vim-bbye or similar plugins to delete buffers. Just like i3/sway I do not think you should use WSc (close current workspace/tab) bcz empty workspaces will close automatically now.
 
 if you are using airline following setting produce best result:
@@ -52,13 +60,6 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
-
-## changes compare to original
-* Can move buffers between tabs
-* :e, C-^, C-0, gd, gf will try to seek buffer last tab and window 
-* Closing tab now move old buffer to previous left pos tab, 
-* Empty workspace (tabs) are actually removed
-* :bd should work fine
 
 # workspace.vim
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 ## changes compare to original
 
--Open existing buffer switch to that buffer.
+-Open existing buffer switch to that tab/buffer.
 -Move tab between working spaces.
 -C-^ move to that tab/buffer
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,11 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
 
+## changes compare to original
+
+-Open existing buffer switch to that buffer.
+-Move tab between working spaces.
+-C-^ move to that tab/buffer
 
 # workspace.vim
 

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ let g:airline#extensions#tabline#show_tab_count = 2
 * Can move tab between working spaces.
 * C-^ switch tab then buffer.
 * Closing tab now move old buffer to previous left tab, if not then first tab.
+* Do not show empty workspaces (copied from original res)
 
 # workspace.vim
 

--- a/readme.md
+++ b/readme.md
@@ -7,12 +7,13 @@ Forked following (workspace.vim) project. It allow to use tabs as workspaces to 
 Please clean and reinstall from repository (last change: 2020-11-07 : airline-intergration)
 
 ## Changes compare to original
-* Can move buffers between tabs
-* :e, C-^, C-0, gd, gf, marks will try to seek buffer last tab and window 
-* Closing tab now move old buffer to previous left pos tab, 
-* Empty workspace (tabs) are actually removed
-* :bd should work fine
-* Also check original fork bcz he is progressing too =D
+
+- Can move buffers between tabs
+- :e, C-^, C-0, gd, gf, marks will try to seek buffer last tab and window
+- Closing tab now move old buffer to previous left pos tab,
+- Empty workspace (tabs) are actually removed
+- :bd should work fine
+- Also check original fork bcz he is progressing too =D
 
 ## My bindings and .vimrc
 
@@ -50,31 +51,36 @@ To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ev
 
 ## Airline integration
 
-``` non-offecial airline intergration, see screenshot below
+```non-offecial airline intergration, see screenshot below
+let g:workspace#vim#airline#enable = 1
+.
+.
+.
+call plug#begin('~/.vim/plugged')
+Plug 'ahmadie/workspace.vim'
+Plug 'vim-airline/vim-airline'
+call plug#end()
+.
+.
+.
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#show_tabs = 0
 let g:airline#extensions#tabline#show_tab_count = 0
-let g:workspace#vim#airline#enable = 1
 ```
 
 ## Additional Usage. Refer Below for more
 
-* `:WSmbv n` will move current buffer to workspace `n` (it is a number).
+- `:WSmbv n` will move current buffer to workspace `n` (it is a number).
 
 ## Images (Workspace <1> | 2)
 
 ![screenshot_2020-11-07-162650](https://user-images.githubusercontent.com/355729/98434787-1decfe00-2116-11eb-9315-7efe9b497999.png)
 
-
 ![screenshot_2020-11-02-020612](https://user-images.githubusercontent.com/355729/97809539-b9164b80-1cb0-11eb-9e95-7e5837c81133.png)
-
 
 ![screenshot_2020-11-02-020637](https://user-images.githubusercontent.com/355729/97809527-aef44d00-1cb0-11eb-908a-a692f29eafd3.png)
 
-
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
-
-
 
 # workspace.vim (original Readme)
 
@@ -83,20 +89,20 @@ to manage large number of buffers by letting the user
 keep them grouped separately in workspaces.
 Similar to i3wm workspaces holding different windows.
 
-* Each tabpage represents a workspace.
-* It's like each workspace has it's own buffer list.
-* Workspaces are numbered starting with 1, like tabpages,
+- Each tabpage represents a workspace.
+- It's like each workspace has it's own buffer list.
+- Workspaces are numbered starting with 1, like tabpages,
   but a workspace number wouldn't change as other workspaces are opened and closed.
-* Third party buffer switchers should work as is.
-* The `hidden` option must be on.
+- Third party buffer switchers should work as is.
+- The `hidden` option must be on.
 
 ## Usage
 
-* `:WS n` will switch to workspace `n` (it is a number).
-* `:WSc [n]` will close current workspace or `n`.
-* `:WSmv n` will rename current workspace to `n` (again a number).
-* `:ls`, `:bn`, `:bp` will only operate on those buffers, which belong to the current workspace.
-* Use your favorite buffer switcher.
+- `:WS n` will switch to workspace `n` (it is a number).
+- `:WSc [n]` will close current workspace or `n`.
+- `:WSmv n` will rename current workspace to `n` (again a number).
+- `:ls`, `:bn`, `:bp` will only operate on those buffers, which belong to the current workspace.
+- Use your favorite buffer switcher.
 
 ## Useful addition to .vimrc
 

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,9 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
 
+
+![screenshot_2020-11-07-160424](https://user-images.githubusercontent.com/355729/98434454-19731600-2113-11eb-91ca-ad5ea60e1445.png)
+
 # workspace.vim (original Readme)
 
 The main purpose of this plugin is to make it easier

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,17 @@ let g:airline#extensions#tabline#show_tabs = 0
 let g:airline#extensions#tabline#show_tab_count = 0
 ```
 
+## Known Issue: Tabs & buffers are not Restored from Session.
+
+If you are using Startfiy (or any session managmenet) you will notice that only last opened tab buffers will be restored next time you read a session. The problem is that this plugin will actually &bufflisted=false buffer from other tabs and nvim will not save them to session file. To solve the problem use :tabo just before leaving nvim to clean all tabs and restore all buffers to &bufferlisted=true. A temporarly solution please use following:
+
+```
+augroup closealltabs
+  autocmd!
+  autocmd VimLeavePre * nested :tabo
+augroup END
+```
+
 ## Additional Usage. Refer Below for more
 
 - `:WSmbv n` will move current buffer to workspace `n` (it is a number).

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,9 @@ let g:workspace#vim#airline#enable = 1
 
 ## Images (Workspace <1> | 2)
 
+![screenshot_2020-11-09-142417](https://user-images.githubusercontent.com/355729/98503223-536d2500-2297-11eb-931b-5dcfd694cbaf.png)
+
+
 ![screenshot_2020-11-07-162650](https://user-images.githubusercontent.com/355729/98434787-1decfe00-2116-11eb-9315-7efe9b497999.png)
 
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Forked following (workspace.vim) project. It allow to use tabs as workspaces to 
 
 ## For updating
 
-Please clean and reinstall from repository (last change: 2020-11-07 : airline-intergration)
+Please clean and reinstall from repository (last change: 2020-11-09 : airline-intergration)
 
 ## Changes compare to original
 * Can move buffers between tabs
@@ -67,9 +67,6 @@ let g:workspace#vim#airline#enable = 1
 
 
 ![screenshot_2020-11-07-162650](https://user-images.githubusercontent.com/355729/98434787-1decfe00-2116-11eb-9315-7efe9b497999.png)
-
-
-![screenshot_2020-11-02-020612](https://user-images.githubusercontent.com/355729/97809539-b9164b80-1cb0-11eb-9e95-7e5837c81133.png)
 
 
 ![screenshot_2020-11-02-020637](https://user-images.githubusercontent.com/355729/97809527-aef44d00-1cb0-11eb-908a-a692f29eafd3.png)

--- a/readme.md
+++ b/readme.md
@@ -15,9 +15,9 @@ nnoremap <silent> <leader>3 :WS 3<CR>
 ```
 ```vim
 " move current buffer to tab N
-nnoremap <silent> <leader><leader>1 :WSbm 1<CR>
-nnoremap <silent> <leader><leader>2 :WSbm 2<CR>
-nnoremap <silent> <leader><leader>3 :WSbm 3<CR>
+nnoremap <silent> <leader><leader>1 :WSbmv 1<CR>
+nnoremap <silent> <leader><leader>2 :WSbmv 2<CR>
+nnoremap <silent> <leader><leader>3 :WSbmv 3<CR>
   .
   .
   .

--- a/readme.md
+++ b/readme.md
@@ -44,12 +44,13 @@ endfun
 
 To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ever randomly close parent tabs, please use moll/vim-bbye or similar plugins to delete buffers. Just like i3/sway I do not think you should use WSc (close current workspace/tab) bcz empty workspaces will close automatically now.
 
-if you are using airline following setting produce best result:
+## Airline integration
 
-```vim
+``` non-offecial airline intergration, see screenshot below
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#show_tabs = 0
-let g:airline#extensions#tabline#show_tab_count = 2
+let g:airline#extensions#tabline#show_tab_count = 0
+let g:workspace#vim#airline#enable = 1
 ```
 
 ## Additional Usage. Refer Below for more

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,8 @@ nnoremap <silent> <leader><leader>3 :WSbmv 3<CR>
 ```
 
 ```vim
-" if you are using sessoin (ex. startify) close all tabs before exist, otherwise opened buffers are not restored.
+" if you are using sessoin (ex. startify) close all tabs before exist,
+" otherwise opened buffers are not restored.
 autocmd VimLeavePre * nested call CloseAllTabs()
 
 fun! CloseAllTabs()

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Forked following (workspace.vim) project. It allow to use tabs as workspaces to 
 
 ## Changes compare to original
 * Can move buffers between tabs
-* :e, C-^, C-0, gd, gf will try to seek buffer last tab and window 
+* :e, C-^, C-0, gd, gf, marks will try to seek buffer last tab and window 
 * Closing tab now move old buffer to previous left pos tab, 
 * Empty workspace (tabs) are actually removed
 * :bd should work fine

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,12 @@ nnoremap <silent> <leader><leader>3 :WSbm 3<CR>
   .
   .
 ```
+```vim
+" c-^ alternative
+nnoremap <silent> <leader>` :call WS_Backforth()<CR>
+```
+
+
 to move between buffers use :bn :bp or any buffer plugin.
 
 if you are using airline following setting produce best result:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,3 @@
-Added WSbm to move buffers between tabs, and fix for nvim ...
-
 # workspace.vim
 
 The main purpose of this plugin is to make it easier

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 ## Forked # workspace.vim
 
-Forked following (workspace.vim) project to allow to use tab as workspaces to manage buffers similar to i3/sway.
+Forked following (workspace.vim) project. It allow to use tabs as workspaces to manage buffers similar to i3/sway.
 
-## changes compare to original
+## Changes compare to original
 * Can move buffers between tabs
 * :e, C-^, C-0, gd, gf will try to seek buffer last tab and window 
 * Closing tab now move old buffer to previous left pos tab, 
@@ -61,7 +61,7 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 ![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
 
-# workspace.vim
+# workspace.vim (original Readme)
 
 The main purpose of this plugin is to make it easier
 to manage large number of buffers by letting the user

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ let g:airline#extensions#tabline#show_tab_count = 0
 
 ## Known Issue: Tabs & buffers are not Restored from Session.
 
-If you are using Startfiy (or any session managmenet) you will notice that only last opened tab buffers will be restored next time you read a session. The problem is that this plugin will actually &bufflisted=false buffer from other tabs and nvim will not save them to session file. To solve the problem use :tabo just before leaving nvim to clean all tabs and restore all buffers to &bufferlisted=true. A temporarly solution please use following:
+If you are using Startfiy (or any session managmenet) you will notice that only last opened tab's buffers will be restored next time you read a session. The problem is that this plugin will actually &bufflisted=false buffer from other tabs and nvim will not save them to session file. To solve the problem use :tabo just before leaving nvim to clean all tabs and restore all buffers to &bufferlisted=true. A temporarly solution please use following:
 
 ```
 augroup closealltabs

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,16 @@ let g:airline#extensions#tabline#show_tab_count = 2
 
 * `:WSmb n` will move current buffer to workspace `n` (it is a number).
 
+## Images (Workspace <1> | 2)
+
+![screenshot_2020-11-02-020612](https://user-images.githubusercontent.com/355729/97809539-b9164b80-1cb0-11eb-9e95-7e5837c81133.png)
+
+
+![screenshot_2020-11-02-020637](https://user-images.githubusercontent.com/355729/97809527-aef44d00-1cb0-11eb-908a-a692f29eafd3.png)
+
+
+![screenshot_2020-11-02-020654](https://user-images.githubusercontent.com/355729/97809516-a6037b80-1cb0-11eb-8def-b6aacd4b11e3.png)
+
 
 # workspace.vim
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@ forked following project to allow to use tab as workspaces to manage buffers sim
 
 my binding are:
 
+```vim
 " create a new tab with N title or move to an exiting N tab.
 nnoremap <silent> <leader>1 :WS 1<CR>
 nnoremap <silent> <leader>2 :WS 2<CR>
@@ -11,7 +12,8 @@ nnoremap <silent> <leader>3 :WS 3<CR>
   .
   .
   .
-
+```
+```vim
 " move current buffer to tab N
 nnoremap <silent> <leader><leader>1 :WSbm 1<CR>
 nnoremap <silent> <leader><leader>2 :WSbm 2<CR>
@@ -19,7 +21,8 @@ nnoremap <silent> <leader><leader>3 :WSbm 3<CR>
   .
   .
   .
-  
+```
+
 ## Additional Usage. Refer Below for more
 
 * `:WSmb n` will move current buffer to workspace `n` (it is a number).

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Forked # workspace.vim
 
-forked following project to allow to use tab as workspaces to manage buffers similar to i3/sway
+Forked following (workspace.vim) project to allow to use tab as workspaces to manage buffers similar to i3/sway
 
 my binding are:
 

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,12 @@ nnoremap <silent> <leader><leader>3 :WSbmv 3<CR>
 ```
 
 ```vim
-" c-^ alternative, i never use this shortcut though ...
-nnoremap <silent> <leader>` :call WS_Backforth()<CR>
+" if you are using sessoin (ex. startify) close all tabs before exist, otherwise opened buffers are not restored.
+autocmd VimLeavePre * nested call CloseAllTabs()
+
+fun! CloseAllTabs()
+  exe 'tabo'
+endfun
 ```
 
 To move between buffers use :bn :bp or any buffer plugin. If deleting buffers ever randomly close parent tabs, please use moll/vim-bbye or similar plugins to delete buffers. Just like i3/sway I do not think you should use WSc (close current workspace/tab) bcz empty workspaces will close automatically now.


### PR DESCRIPTION
1- Create binding for WS_B_Move to WSbm to move buffer to other tabs/workspaces, with small fix.

2- Added new logic to s:tabenter to handle removed buffers from old workspaces. The problem exist in nvim. For example, open buffer A in tab X, then switch to tab Y and open the same buffer A, when you go back to tab X, buffer A display even though it does not exists in buffer list. The new logic will replace buffer A with any other buffer from tab X or create a new empty buffer.